### PR TITLE
Updated manifest to file_config format

### DIFF
--- a/cumulus_library_rxnorm/manifest.toml
+++ b/cumulus_library_rxnorm/manifest.toml
@@ -1,6 +1,6 @@
 study_prefix = "rxnorm"
 
-[table_builder_config]
+[file_config]
 file_names = [
     "rxnorm_builder.py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ version = "1.0"
 name = "cumulus-library-rxnorm"
 requires-python = ">= 3.11"
 dependencies = [
-    "cumulus-library >= 3",
+    "cumulus-library >= 4.1, <7.0",
 ]
-description = "A Unified Medical Language System® Metathesaurus study for the Cumulus project"
+description = "A RxNorm study for the Cumulus project"
 readme = "README.md"
 license = { text="Apache License 2.0" }
 keywords = ["FHIR", "SQL", "Health Informatics"]


### PR DESCRIPTION
This removes the deprecated `table_builder_config` entry in the manifest in favor of the `file_config` equivalent.